### PR TITLE
Adding new 5.0 test: test_target_loop_teams_distribute.cpp

### DIFF
--- a/tests/5.0/target_loop/test_target_loop_teams_distribute.cpp
+++ b/tests/5.0/target_loop/test_target_loop_teams_distribute.cpp
@@ -28,7 +28,7 @@ template <typename T> void saxpy_d(T *x, T *y, T a, int n) {
 
 // SAXPY kernel using the target loop construct
 template <typename T> void saxpy_l(T *x, T *y, T a, int n) {
-#pragma omp target loop map(tofrom : x [0:n]) map(to : y [0:n])
+#pragma omp target teams loop map(tofrom : x [0:n]) map(to : y [0:n])
   for (int i = 0; i < n; ++i)
     x[i] = a * x[i] + y[i];
 }


### PR DESCRIPTION
This test uses the 5.0 loop clause for offloading a SAXPY kernel and verifies that the result is indeed correct. 
After performing some tests the only compiler producing the correct result is nvc++ 21.7. GCC 11 doesn't recognize the clause and clang is unable to produce the correct result.