### PR TITLE
Issue 733: More fixes for test_requires_unified_address.c

### DIFF
--- a/tests/5.0/requires/test_requires_unified_address.c
+++ b/tests/5.0/requires/test_requires_unified_address.c
@@ -27,7 +27,7 @@ int unified_address() {
    if (mem_ptr == NULL)
      return ++errors;
    
-   #pragma omp target map(from:mem_ptr2) /* is_device_ptr(mem_ptr) - which is optional.  */
+   #pragma omp target map(from:mem_ptr2) defaultmap(firstprivate) /* is_device_ptr(mem_ptr) - which is optional.  */
    {
       for (i = 0; i < N; i++) {
          mem_ptr[i] = i + 1;
@@ -38,7 +38,7 @@ int unified_address() {
    /* Pointer arithmetic is permitted; assumes sizeof(int) is the same.  */
    mem_ptr2 += 4;
    
-   #pragma omp target map(tofrom:errors) /* is_device_ptr(mem_ptr2) - which is optional.  */
+   #pragma omp target map(tofrom:errors) defaultmap(to) /* is_device_ptr(mem_ptr2) - which is optional.  */
    for (i = 0; i < N; i++) {
       if(mem_ptr2[i - 5 - 4] != i + 1) {
          errors++;


### PR DESCRIPTION
Issue #733

While using the device address inside the target region does not require **is_device_ptr**, I missed for the previous code a special rule for _implicit mapping,_ namely for C/C++:

"A variable that is of type pointer [...] is treated as if it is the
 base pointer of a zero-length array section that had appeared as a
 list item in a map clause."

Thus, the previous test was invalid. Solution: Ensure the `sizeof(void*)` bytes are actually available on the device and have the value of the host. That can be either done via **firstprivate** or by mapping the pointer. This commit does either - once via **defaultmap(firstprivate)** and once via **defaultmap(to)**.

Sorry for missing it during the first round (→ PR #734). The updated testcase actually now runs with GCC.

@spophale @fel-cab — can you review the follow up to fix my snafu?