### PR TITLE
Resolving issue 817.

### DIFF
--- a/tests/5.0/target_update/test_target_update_mapper_from_discontiguous.c
+++ b/tests/5.0/target_update/test_target_update_mapper_from_discontiguous.c
@@ -38,7 +38,7 @@ int target_update_from_mapper() {
     #pragma omp target
     { 
       for (int i = 0; i < s.len; i++) {
-        s.data[i] = 10;
+        s.data[i] = i;
       }
     }//end target
   
@@ -50,7 +50,7 @@ int target_update_from_mapper() {
       OMPVV_TEST_AND_SET(errors, s.data[i] != 0);
     }
     else{
-      OMPVV_TEST_AND_SET(errors, s.data[i] != 10);
+      OMPVV_TEST_AND_SET(errors, s.data[i] != i);
     }
   }
 

--- a/tests/5.0/target_update/test_target_update_mapper_from_discontiguous.c
+++ b/tests/5.0/target_update/test_target_update_mapper_from_discontiguous.c
@@ -17,7 +17,7 @@
 #define N 1024
 
 typedef struct{
-  size_t len;
+  int len;
   int *data;
 } T;
 

--- a/tests/5.0/target_update/test_target_update_mapper_from_discontiguous.c
+++ b/tests/5.0/target_update/test_target_update_mapper_from_discontiguous.c
@@ -14,11 +14,11 @@
 #include <stdlib.h>
 #include "ompvv.h"
 
-#define N 10
+#define N 1024
 
 typedef struct{
   size_t len;
-  double *data;
+  int *data;
 } T;
 
 int errors = 0;
@@ -30,7 +30,7 @@ int target_update_from_mapper() {
   T s;
   
   s.len = N;
-  s.data = (double *)calloc(N,sizeof(double));
+  s.data = (int *)calloc(N,sizeof(int));
   
   
    #pragma omp target data map(mapper(custom), to:s) 
@@ -47,7 +47,7 @@ int target_update_from_mapper() {
 
   for (int i =0; i < s.len; i++) {
     if(i%2){
-      OMPVV_TEST_AND_SET(errors, s.data[i] != 0.00);
+      OMPVV_TEST_AND_SET(errors, s.data[i] != 0);
     }
     else{
       OMPVV_TEST_AND_SET(errors, s.data[i] != 10);


### PR DESCRIPTION
closes #817 

This resolves the missing data issue. But the test fails with both LLVM clang and amdclang as neither account for the stride specified in the target update.

Example:

`#pragma omp target update from(s.data[:N/2:2]) //only update even array elements`

Results in:
```
s.data[0]:10.000000 
s.data[1]:10.000000 
s.data[2]:10.000000 
s.data[3]:10.000000 
s.data[4]:10.000000 
s.data[5]:0.000000 
s.data[6]:0.000000 
s.data[7]:0.000000 
s.data[8]:0.000000 
s.data[9]:0.000000 
```