### PR TITLE
fix_issue_643/test_target_update_mapper_from_discontiguous.F90

### DIFF
--- a/tests/5.0/target_update/test_target_update_mapper_from_discontiguous.F90
+++ b/tests/5.0/target_update/test_target_update_mapper_from_discontiguous.F90
@@ -16,8 +16,8 @@
 
 module my_struct
   type newvec
-    integer                     :: len
-    double precision, pointer   :: data(:)
+    integer            :: len
+    integer, pointer   :: data(:)
   end type
 end module
 
@@ -41,23 +41,29 @@ CONTAINS
     INTEGER FUNCTION test_target_update_mapper_from()
         INTEGER :: i 
         !$omp declare mapper(newvec :: v)&
-        !$omp& map(v, v%data(1:v%len))
+        !$omp& map(to: v, v%data(1:v%len))
 
         type(newvec) :: s
         allocate(s%data(N))
         s%len = N
-        s%data(1:N) = 0.0d0
+        s%data(1:N) = 0
 
+        !$omp target data map(to:s)
         !$omp target 
-        DO i=1, s%len, 2
-           s%data(i) = i
+        DO i=1, s%len
+            s%data(i) = i
         END DO
         !$omp end target
 
-        !$omp target update from(s)
+        !$omp target update from(s%data(1:s%len:2))
+        !$omp end target data
 
-        DO i=1, s%len, 2
-           OMPVV_TEST_AND_SET(errors, s%data(i) /= i)
+        DO i=1, s%len
+           IF (modulo(i,2) .EQ. 0) THEN
+                OMPVV_TEST_AND_SET(errors, s%data(i) /= 0)
+            ELSE
+                OMPVV_TEST_AND_SET(errors, s%data(i) /= i)
+            END IF
         END DO
 
         test_target_update_mapper_from = errors

--- a/tests/5.0/target_update/test_target_update_mapper_from_discontiguous.F90
+++ b/tests/5.0/target_update/test_target_update_mapper_from_discontiguous.F90
@@ -40,7 +40,7 @@ PROGRAM test_target_update_mapper_from_discontiguous
 CONTAINS
     INTEGER FUNCTION test_target_update_mapper_from()
         INTEGER :: i 
-        !$omp declare mapper(newvec :: v)&
+        !$omp declare mapper(custom: newvec :: v)&
         !$omp& map(to: v, v%data(1:v%len))
 
         type(newvec) :: s
@@ -48,7 +48,7 @@ CONTAINS
         s%len = N
         s%data(1:N) = 0
 
-        !$omp target data map(to:s)
+        !$omp target data map(mapper(custom), to:s)
         !$omp target 
         DO i=1, s%len
             s%data(i) = i


### PR DESCRIPTION
[Fix issue #643]
Update test_target_update_mapper_from_discontiguous.F90 and test_target_update_mapper_to_discontiguous.F90 to have the same behaviors as the corresponding C versions.
GCC 14.1.1 can compile and run both versions correctly on Summit.