### PR TITLE
Adding change to ftn command line flags in make.def.

### DIFF
--- a/sys/make/make.def
+++ b/sys/make/make.def
@@ -255,7 +255,7 @@ ifeq ($(FC), ftn)
   FLINK          = cc
   FOFFLOADING    = -fopenmp
   F_NO_OFFLOADING = -hnoomp
-  FFLAGS         += -lm -J./ompvv -O3 $(FOFFLOADING)
+  FFLAGS         += -lm -dm -O3 $(FOFFLOADING)
   FLINKFLAGS     += -lm -O3 $(FOFFLOADING)
 endif
 


### PR DESCRIPTION
issue #843 
Removed -J flag and added in -dm to the make.def
Below image shows that Fortran files continue to pass when using --jobs=12 in the makefile
![passAll](https://github.com/user-attachments/assets/d29ecd82-dadb-4d94-a52d-38d9785a1377)
