### PR TITLE
Adding the tests for map-type modifier with default properties.

### DIFF
--- a/tests/6.0/map-type_modifier/test_map-type_modifier_default.c
+++ b/tests/6.0/map-type_modifier/test_map-type_modifier_default.c
@@ -20,11 +20,12 @@ int test_maptype_modifier_default() {
 
   #pragma omp target enter data map(to : a)
 
-  #pragma omp target map(present, from : a)
+  #pragma omp target map(present)
   {
     a = a * N;
   }
-  #pragma omp target update from(a)
+
+  #pragma omp target exit data map(from: a)
 
   OMPVV_TEST_AND_SET_VERBOSE(errors, a != N)
   return errors;

--- a/tests/6.0/map-type_modifier/test_map-type_modifier_default.c
+++ b/tests/6.0/map-type_modifier/test_map-type_modifier_default.c
@@ -1,0 +1,35 @@
+//--------------test_map-type_modifier_default.c-----------------------------------//
+// OpenMP API Version 6.0 November 2024
+// Pg. 899, line 12
+// ***********
+// DIRECTIVE:target
+// CLAUSE:map
+// ***********
+// The default properties behavior of the map-type modifier supplied to the map
+// clause is being tested. Providing two arguments (to and from) ensures that
+// more than one modifier can be supplied at once to map. This is in accordance
+// with the modifier defaults column in Table 5.1 on page 159. If a tofrom
+// behavior is observed at runtime, then the test passes.
+//---------------------------------------------------------------------------------//
+#include "ompvv.h"
+
+#define N 2
+
+int test_maptype_modifier_default() {
+  int errors = 0, a = 1;
+
+  #pragma omp target map(to: a, from: a)
+  {
+    a = a * N;
+  }
+
+  OMPVV_TEST_AND_SET_VERBOSE(errors, a != N)
+  return errors;
+}
+
+int main() {
+  int errors = 0;
+  OMPVV_TEST_AND_SET(errors, test_maptype_modifier_default() != 0);
+  OMPVV_REPORT_AND_RETURN(errors);
+  return errors;
+}

--- a/tests/6.0/map-type_modifier/test_map-type_modifier_default.c
+++ b/tests/6.0/map-type_modifier/test_map-type_modifier_default.c
@@ -6,10 +6,10 @@
 // CLAUSE:map
 // ***********
 // The default properties behavior of the map-type modifier supplied to the map
-// clause is being tested. Providing two arguments (to and from) ensures that
-// more than one modifier can be supplied at once to map. This is in accordance
-// with the modifier defaults column in Table 5.1 on page 159. If a tofrom
-// behavior is observed at runtime, then the test passes.
+// clause is being tested. Providing the present modifier and a from modifier
+// ensures that more than one modifier can be supplied at once to map. This is
+// in accordance with the modifier defaults column in Table 5.1 on page 159. If
+// a tofrom behavior is observed at runtime, then the test passes.
 //---------------------------------------------------------------------------------//
 #include "ompvv.h"
 
@@ -18,10 +18,13 @@
 int test_maptype_modifier_default() {
   int errors = 0, a = 1;
 
-  #pragma omp target map(present, tofrom:a)
+  #pragma omp target enter data map(to : a)
+
+  #pragma omp target map(present, from : a)
   {
     a = a * N;
   }
+  #pragma omp target update from(a)
 
   OMPVV_TEST_AND_SET_VERBOSE(errors, a != N)
   return errors;

--- a/tests/6.0/map-type_modifier/test_map-type_modifier_default.c
+++ b/tests/6.0/map-type_modifier/test_map-type_modifier_default.c
@@ -6,10 +6,10 @@
 // CLAUSE:map
 // ***********
 // The default properties behavior of the map-type modifier supplied to the map
-// clause is being tested. Providing the present modifier and a from modifier
-// ensures that more than one modifier can be supplied at once to map. This is
-// in accordance with the modifier defaults column in Table 5.1 on page 159. If
-// a tofrom behavior is observed at runtime, then the test passes.
+// clause is being tested. Providing the present modifier with no additional
+// map-type modifier ensures that more than one modifier is not needed for
+// the map. This is in accordance with the modifier defaults column in Table 5.1 
+// on page 159. If a tofrom behavior is observed at runtime, then the test passes.
 //---------------------------------------------------------------------------------//
 #include "ompvv.h"
 

--- a/tests/6.0/map-type_modifier/test_map-type_modifier_default.c
+++ b/tests/6.0/map-type_modifier/test_map-type_modifier_default.c
@@ -20,7 +20,7 @@ int test_maptype_modifier_default() {
 
   #pragma omp target enter data map(to : a)
 
-  #pragma omp target map(present)
+  #pragma omp target map(present: a)
   {
     a = a * N;
   }

--- a/tests/6.0/map-type_modifier/test_map-type_modifier_default.c
+++ b/tests/6.0/map-type_modifier/test_map-type_modifier_default.c
@@ -18,7 +18,7 @@
 int test_maptype_modifier_default() {
   int errors = 0, a = 1;
 
-  #pragma omp target map(to: a, from: a)
+  #pragma omp target map(present, tofrom:a)
   {
     a = a * N;
   }


### PR DESCRIPTION
CC = clang 21.0.0git
test_map-type_modifier_default.c.o:
omptarget message: device mapping required by 'present' map type modifier does not exist for host address 0x00007ffe9ed6eda4 (4 bytes)
omptarget error: Call to getTargetPointer returned null pointer ('present' map type modifier).
omptarget error: Call to targetDataBegin failed, abort target.
omptarget error: Failed to process data before launching the kernel.
omptarget error: Consult https://openmp.llvm.org/design/Runtimes.html for debugging options.
omptarget error: Source location information not present. Compile with -g or -gline-tables-only.
omptarget fatal error 1: failure of target construct while offloading is mandatory
timeout: the monitored command dumped core