### PR TITLE
Added notdir comparison to fix issue of being unable to supply absolute paths to compiler definition for the makefile.

### DIFF
--- a/sys/make/make.def
+++ b/sys/make/make.def
@@ -64,8 +64,12 @@ endef
 CCOMPILERS?="amdclang, cc, clang, gcc, xlc, xlc_r, icx, icpx, nvc"
 C_VERSION?= echo "version unknown"
 CC?=none
-CPP?=none
+CXX?=none
 FC?=none
+
+override CC := $(notdir $(CC))
+override CXX := $(notdir $(CXX))
+override FC := $(notdir $(FC))
 
 ifeq ($(OMP_VERSION), 5.0)
    OMPV = -fopenmp-version=50


### PR DESCRIPTION
Solving issue #34 
The modified CC, CXX, and FC definitions were tested by supplying an absolute path to each variable (one at a time) and running `make` with the all option for the respective offloading_success tests.
