### PR TITLE
Changing the offloading architecture flag from native to frontier specific arch.

### DIFF
--- a/sys/make/make.def
+++ b/sys/make/make.def
@@ -233,7 +233,7 @@ F_VERSION?= echo "version unknown"
 ifeq ($(FC), amdflang)
     F_VERSION     =  $(FC) -dumpversion
     FLINK         =  amdclang++
-    FOFFLOADING   =  -fopenmp --offload-arch=native 
+    FOFFLOADING   =  -fopenmp --offload-arch=gfx90a
     FOFFLOADING   +=  $(OMPV)
     FFLAGS        += -lm -O3 $(FOFFLOADING)
     FLINKFLAGS    += -lm -O3 $(FOFFLOADING)


### PR DESCRIPTION
 rocm6.3.1 (the latest on Frontier) is not able to use native, as the flang-classic frontend is still used in the associated amdflang.
The testsuite was run with amdflang using this edited flag, and the passing numbers seem to be consistent with prior results that used this specified architecture.