### PR TITLE
Issue 863: test_interop_target.c - remove nowait from 'interop destroy' to fix dependency

### DIFF
--- a/tests/5.1/interop/test_interop_target.c
+++ b/tests/5.1/interop/test_interop_target.c
@@ -39,7 +39,7 @@ int interopTestTarget() {
 
   }
 
-  #pragma omp interop destroy(obj) nowait depend(out: A[0:N])
+  #pragma omp interop destroy(obj) depend(out: A[0:N])
 
   // Interop should be completed and cleaned up by here
   


### PR DESCRIPTION
* Fixes Issue #863 

The 'depend' clause clause is required to avoid the race between writing the data (before the 'interop' directive) and reading it without further synchronisation after the interop destroy line.

However, with 'nowait' it handles the tracking in the background to handle the dependency correctly for the streaming object (targetsync) but as it is run asynchronously, the host code proceeds to the reading code - and failed.

By removing the 'nowait', the host code is only excuted after the stream (with dependency tracking) is processed; the actual stream processing should take no time as no actual stream processing is happening.

@fel-cab @spophale @nolanbaker31 @jrreap @seyonglee: Please review