### PR TITLE
Issue 868: Fix 5.1/target/test_target_map_iterators.{F90,c}

### DIFF
--- a/tests/5.1/target/test_target_map_iterators.F90
+++ b/tests/5.1/target/test_target_map_iterators.F90
@@ -28,23 +28,28 @@ PROGRAM test_target_map_iterator
 CONTAINS
   INTEGER FUNCTION test_map_iterator()
     INTEGER :: errors, i, listsum
-    INTEGER, DIMENSION(N) :: test_lst
+    TYPE t
+      INTEGER, POINTER :: ptr
+    END TYPE t
+    TYPE(t), DIMENSION(N) :: test_lst
 
     errors = 0
     listsum = 0
 
     DO i=1, N
-      test_lst(i) = 1
+      allocate(test_lst(i)%ptr)
+      test_lst(i)%ptr = 1
     END DO
 
-    !$omp target map(iterator(it = 1:N), tofrom: test_lst(it))
+    !$omp target map(iterator(it = 1:N), tofrom: test_lst(it)%ptr) map(test_lst)
     DO i=1, N
-      test_lst(i) = 2
+      test_lst(i)%ptr = 2
     END DO
     !$omp end target
 
     DO i=1, N
-      listsum = listsum + test_lst(i)
+      listsum = listsum + test_lst(i)%ptr
+      deallocate(test_lst(i)%ptr)
     END DO
 
     OMPVV_TEST_AND_SET(errors, listsum .NE. 2*N)

--- a/tests/5.1/target/test_target_map_iterators.c
+++ b/tests/5.1/target/test_target_map_iterators.c
@@ -19,18 +19,20 @@
 int test_case(){
 	int errors = 0;
 	int sum = 0;
-	int test_lst[N];
+	int *test_lst[N];
 	for (int i = 0; i<N; i++){
-		test_lst[i] = 1;
+		test_lst[i] = (int *) malloc(sizeof(int));
+		test_lst[i][0] = 1;
 	}
-	#pragma omp target map(iterator(it = 0:N), tofrom: test_lst[it])
+	#pragma omp target map(iterator(it = 0:N), tofrom: test_lst[it][:1]) map(to: test_lst)
 	{
 		for(int i = 0; i < N; i++){
-			test_lst[i] = 2;
+			test_lst[i][0] = 2;
 		}
 	}
 	for (int i = 0; i < N; i++){
-		sum += test_lst[i];
+		sum += test_lst[i][0];
+		free(test_lst[i]);
 	}
 	OMPVV_TEST_AND_SET(errors, (sum != 2*N));
 	return (errors);


### PR DESCRIPTION
* Fixes Issue #868

OpenMP does not permit using the same containing array with the iterator modifier to the map clause (i.e. `array[i]`).

Solution: Make the testcase valid and more sensible by using an array of pointers to integer instead of a plain integer array, i.e. use `ptrarry[i][:1]` instead.
