### PR TITLE
Adding the initial test.

### DIFF
--- a/tests/5.0/loop/test_loop_iterator.F90
+++ b/tests/5.0/loop/test_loop_iterator.F90
@@ -28,23 +28,18 @@ CONTAINS
   INTEGER FUNCTION test_loop_iterator()
   INTEGER :: errors = 0
   REAL :: a(N)
-  INTEGER :: i, num_threads = 0
+  INTEGER :: i, temp = 0
 
-  !$omp parallel
-  !$omp single
-    num_threads = omp_get_num_threads()
-  !$omp end single
-
-  !$omp target map(a, i)
+  !$omp target map(from: temp)
   !$omp loop
   DO i = 1, N
     a(i) = i
   END DO
   !$omp end loop
+  temp = i
   !$omp end target
-  !$omp end parallel
 
-  OMPVV_TEST_AND_SET(errors, i .NE. N+1)
+  OMPVV_TEST_AND_SET(errors, temp .NE. N+1)
   test_loop_iterator = errors
 
   END FUNCTION test_loop_iterator


### PR DESCRIPTION
Test compiles and passes with gfortran 15.1
fails with flang
[header test_loop_iterator.F90:24]  Condition condition failed
[header test_loop_iterator.F90:23] Test is running on device
[header ompvv.F90:253] The value of errors is 2
[OMPVV_RESULT test_loop_iterator.F90] Test failed on the device.
Fortran STOP: code 1

This PR resolves issue #862 