### PR TITLE
Adding the first workdistribute test

### DIFF
--- a/tests/6.0/workdistribute/test_workdistribute_directive.F90
+++ b/tests/6.0/workdistribute/test_workdistribute_directive.F90
@@ -74,7 +74,7 @@ program test_omp_workdistribute
 
 
     integer :: errors = 0
-    integer, parameter :: N = 1024 * 1024
+    integer, parameter :: N = 1024
 
     real :: a
     real :: x0


### PR DESCRIPTION
Compiles and crashes with flang 22.
Compiles and dumps core with gfortran 14

For gfortran this happens when
integer, parameter :: N >= 1024 * 1016