### PR TITLE
Issue 908: Fix 5.1 test_target_update_iterator.F90

### DIFF
--- a/tests/5.1/target_update/test_target_update_iterator.F90
+++ b/tests/5.1/target_update/test_target_update_iterator.F90
@@ -65,7 +65,7 @@ CONTAINS
         CALL init(new_struct)
 
         !$omp target enter data map(to: new_struct%data)
-        !$omp target map(to: new_struct, new_struct%data) map(tofrom: A) 
+        !$omp target map(to: new_struct%data) map(tofrom: A) private(i)
         ! pointer attachment
         DO i = 1, N
             A(i) = new_struct%data(i)
@@ -75,7 +75,7 @@ CONTAINS
         CALL init_again(new_struct)
         ! update with new values, (i*2)+1
         !$omp target update to(iterator(it = 1:N): new_struct%data(it))
-        !$omp target map(tofrom: A)
+        !$omp target map(tofrom: A) private(i)
         DO i = 1, N
             A(i) = A(i) + new_struct%data(i)
         END DO


### PR DESCRIPTION
fixes #908
* Issue #908

The code used `target enter data map(to: new_struct%data)` to map part of the derived type - and later tries to explicitly map all of the derived type: `target map(to: new_struct, new_struct%data)`.

A permissible implementation is to only map parts of 'new_struct' in the 'enter data' directive such that mapping all of 'new_struct' is not permitted (unspecified behavior), leading to a runtime fail.

**Solution** is to **either** only _implicitly map_ 'new_struct', which handles partial mapping - **or** as **done here:** `target map(to: new_struct%data)`, i.e. _only_ mapping what is already present on the device (no actual data copy happening here).

Additionally, `private(i)` has been added as otherwise an _implicit_ `firstprivate(i)` is added that uses uninitialized memory.

@fel-cab @spophale @seyonglee @andrewkallai