### PR TITLE
 Issue 907: Make 5.1/atomic/test_atomic_fail_*.{c,F90} less racy

### DIFF
--- a/tests/5.1/atomic/test_atomic_fail_acquire.F90
+++ b/tests/5.1/atomic/test_atomic_fail_acquire.F90
@@ -36,10 +36,10 @@ CONTAINS
     !$omp parallel num_threads(2) private(thrd)
     thrd = omp_get_thread_num()
     IF( thrd .EQ. 0 ) THEN
-      y = 1
       !$omp atomic write seq_cst 
       x = 10
       !$omp end atomic
+      y = 1
     ELSE
       DO WHILE ( y .NE. 5 )
         !$omp atomic compare seq_cst fail(acquire)

--- a/tests/5.1/atomic/test_atomic_fail_acquire.c
+++ b/tests/5.1/atomic/test_atomic_fail_acquire.c
@@ -25,9 +25,9 @@ int test_atomic_fail_acquire() {
    {
       int thrd = omp_get_thread_num();
        if (thrd == 0) {
-          y = 1;
           #pragma omp atomic write seq_cst
           x = 10;
+          y = 1;
        } else {
           while (y != 5) {
             #pragma omp atomic compare seq_cst fail(acquire)

--- a/tests/5.1/atomic/test_atomic_fail_relaxed.F90
+++ b/tests/5.1/atomic/test_atomic_fail_relaxed.F90
@@ -36,10 +36,10 @@ CONTAINS
     !$omp parallel num_threads(2) private(thrd)
     thrd = omp_get_thread_num()
     IF( thrd .EQ. 0 ) THEN
-      y = 1
       !$omp atomic write seq_cst 
       x = 10
       !$omp end atomic
+      y = 1
     ELSE
       DO WHILE ( y .NE. 5 )
         !$omp atomic compare fail(relaxed)

--- a/tests/5.1/atomic/test_atomic_fail_relaxed.c
+++ b/tests/5.1/atomic/test_atomic_fail_relaxed.c
@@ -25,9 +25,9 @@ int test_atomic_fail_relaxed() {
    {
       int thrd = omp_get_thread_num();
        if (thrd == 0) {
-          y = 1;
           #pragma omp atomic write seq_cst
           x = 10;
+          y = 1;
        } else {
           while (y != 5) {
             #pragma omp atomic compare fail(relaxed)

--- a/tests/5.1/atomic/test_atomic_fail_seq_cst.F90
+++ b/tests/5.1/atomic/test_atomic_fail_seq_cst.F90
@@ -37,10 +37,10 @@ CONTAINS
     !$omp parallel num_threads(2) private(thrd, tmp)
     thrd = omp_get_thread_num()
     IF( thrd .EQ. 0 ) THEN
-      y = 1
       !$omp atomic write seq_cst 
       x = 10
       !$omp end atomic
+      y = 1
     ELSE
       tmp = 0
       DO WHILE ( y .NE. 5 )

--- a/tests/5.1/atomic/test_atomic_fail_seq_cst.c
+++ b/tests/5.1/atomic/test_atomic_fail_seq_cst.c
@@ -25,9 +25,9 @@ int test_atomic_fail_seq_cst() {
    {
       int thrd = omp_get_thread_num();
        if (thrd == 0) {
-          y = 1;
           #pragma omp atomic write seq_cst
           x = 10;
+          y = 1;
        } else {
           while (y != 5) {
             #pragma omp atomic compare acquire fail(seq_cst)


### PR DESCRIPTION
fixes #907
* Issue #907

The current code sets `y = 1` and then atomically `x = 10` in the first thread, expecting that once 'y' shows up as updated in the second thread, 'x' is also updated. - But this is racy.

With this commit, 'y' is set non atomically after the atomic write.

This applies to all 6 `tests: tests/5.1/atomic/test_atomic_fail_{acquire,relexed,seq_cst}.{c,F90}.`