### PR TITLE
test_parallel_num_threads_prescriptiveness.c: Fix modifier use

### DIFF
--- a/tests/6.0/parallel/test_parallel_num_threads_prescriptiveness.c
+++ b/tests/6.0/parallel/test_parallel_num_threads_prescriptiveness.c
@@ -8,10 +8,10 @@
 // ***********
 //
 // This test checks the prescriptiveness modifier for the num_threads clause on the
-// parallel directive. When prescriptiveness(strict) is specified, the implementation
+// parallel directive. When 'strict' is specified, the implementation
 // must respect the requested number of threads when dyn-var is false and sufficient
 // threads are available. The test verifies that when OMP_DYNAMIC is false and
-// num_threads(prescriptiveness(strict): N) is used, exactly N threads execute.
+// num_threads(strict: N) is used, exactly N threads execute.
 //
 //===-------------------------------------------------------------------------===//
 
@@ -22,7 +22,7 @@ int test_num_threads_prescriptiveness() {
   int errors = 0;
   int actual_threads = 0;
 
-  #pragma omp parallel num_threads(prescriptiveness(strict): OMPVV_NUM_THREADS_HOST)
+  #pragma omp parallel num_threads(strict: OMPVV_NUM_THREADS_HOST)
   {
     #pragma omp single
     {
@@ -32,9 +32,9 @@ int test_num_threads_prescriptiveness() {
 
   OMPVV_TEST_AND_SET(errors, actual_threads != OMPVV_NUM_THREADS_HOST);
   OMPVV_INFOMSG_IF(actual_threads == OMPVV_NUM_THREADS_HOST,
-                   "prescriptiveness(strict): Obtained %d threads as requested.", actual_threads);
+                   "prescriptiveness 'strict': Obtained %d threads as requested.", actual_threads);
   OMPVV_ERROR_IF(actual_threads != OMPVV_NUM_THREADS_HOST,
-                 "prescriptiveness(strict): Expected %d threads, got %d.",
+                 "prescriptiveness 'strict': Expected %d threads, got %d.",
                  OMPVV_NUM_THREADS_HOST, actual_threads);
   return errors;
 }


### PR DESCRIPTION
The _prescriptiveness_ modifier to **num_threads** is `strict` (and since TR15 (OpenMP 6.1) also `relaxed`) and not `prescriptiveness(strict)`.

Hence, in the following testcase `num_threads(prescriptiveness(strict) : N)` should actually be `num_threads(strict : N)` [cross ref: the file was added in Pull Req. #912]:

https://github.com/OpenMP-Validation-and-Verification/OpenMP_VV/blob/658ec4186cb57037d4a70b7a897440bb2419341f/tests/6.0/parallel/test_parallel_num_threads_prescriptiveness.c#L25

If you look at the specification (here: 6.0) `strict` is the keyword – in 6.1 (TR15) there is also `relaxed` – and both keywords run under _prescriptiveness_. [Note also that a type font is used for the keyword and for italic for the name.] 

<img width="677" height="241" alt="grafik" src="https://github.com/user-attachments/assets/a4d20031-bff3-422e-82b5-2d5ff3cb7bf3" />

* * *
@andrewkallai @seyonglee @spophale – Please review.