### PR TITLE
Issue 915: Fix [[omp::decl(...)]] attribute use in test_cpp_decl_attribute2.cpp

### DIFF
--- a/tests/6.0/decl_attribute/test_cpp_decl_attribute2.cpp
+++ b/tests/6.0/decl_attribute/test_cpp_decl_attribute2.cpp
@@ -3,25 +3,29 @@
 // OpenMP API Version 6.0 November 2024
 //
 // ***********
-// DIRECTIVE:target
-// CLAUSE:map
+// DIRECTIVE:declare target
+// CLAUSE:enter
 // ***********
 //
 // This test checks the usage of the decl attribute for a directive-specification 
-// with target as the directive and map as the optional clause. The test will pass
-// when offloading succeeds or when num_devices == 0.
+// with declare target as the directive and enter as the optional clause. The test
+// will pass when offloading succeeds or when num_devices == 0.
 //
 //===-------------------------------------------------------------------------===//
 #include <omp.h>
 #include "ompvv.h"
 
+[[omp :: decl(declare target, enter)]] int on_host;
+
+[[omp :: decl(declare target)]]
+void update() { on_host = omp_is_initial_device(); }
+
 int main(void) {
   int errors = 0;
-  int on_host = 1;
   int num_devices = omp_get_num_devices();
 
-  [[omp :: decl( target map(from: on_host) )]]
-  { on_host = omp_is_initial_device(); }
+  [[omp :: directive(target, map(always, from: on_host))]]
+  { update(); }
 
   if (num_devices > 0) {
     OMPVV_ERROR_IF(

--- a/tests/6.0/decl_attribute/test_cpp_decl_attribute2.cpp
+++ b/tests/6.0/decl_attribute/test_cpp_decl_attribute2.cpp
@@ -15,7 +15,7 @@
 #include <omp.h>
 #include "ompvv.h"
 
-[[omp :: decl(declare target, enter)]] int on_host;
+[[omp :: decl(declare target, enter)]] int on_host = 1;
 
 [[omp :: decl(declare target)]]
 void update() { on_host = omp_is_initial_device(); }


### PR DESCRIPTION
Use the 'omp::decl' attribute with the declarative directive 'declare target' instead of with an executive directive like 'target'.

For the 'target' directives, it switches to '[[omp::directive(target)]]'; the assumption is that a compiler supporting OpenMP 6.0's 'omp::decl' will also support OpenMP 5.1's 'omp::directive'.
***
fixes #915
* Issue #915
***
@fel-cab @spophale @andrewkallai – Please review.

Testing it with the GCC compiler (Linux distro compiler):
```
$ /usr/bin/gcc-16 -fopenmp -Wall -I ompvv tests/6.0/decl_attribute/test_cpp_decl_attribute2.cpp 
$ ./a.out 
Target region executed on the device

$ /usr/bin/gcc-14 -fopenmp -Wall -I ompvv tests/6.0/decl_attribute/test_cpp_decl_attribute2.cpp
$ OMP_TARGET_OFFLOAD=disabled ./a.out
Target region executed on the host
```
